### PR TITLE
Clarify array broadcasting behavior in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 <img src="https://raw.githubusercontent.com/numpy/numpy/main/branding/logo/primary/numpylogo.svg" width="300">
 </h1><br>
 
+> 📘 NumPy supports array broadcasting, allowing operations on arrays of different shapes as long as they are compatible under broadcasting rules.
 
 [![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](
 https://numfocus.org)


### PR DESCRIPTION
Added a one-line note at the top of README.md to briefly explain NumPy’s broadcasting capabilities for array operations.